### PR TITLE
Fix On-Boot eval

### DIFF
--- a/lua/aolite/ao/boot.lua
+++ b/lua/aolite/ao/boot.lua
@@ -33,7 +33,11 @@ return function(ao)
       return
     end
     if msg.Tags["On-Boot"] == "Data" then
-      eval.eval(msg)
+      -- When the On-Boot tag is "Data" we expect the process source
+      -- code to be provided in the Data field of the message. The
+      -- evaluate function expects a string expression, so pass the
+      -- message data directly instead of the full message table.
+      eval.eval(msg.Data, "Eval")
     else
       local loadedVal = drive.getData(msg.Tags["On-Boot"])
       -- log.debug("Loaded: ", loadedVal)


### PR DESCRIPTION
## Summary
- fix eval of On-Boot `Data` messages in boot module

## Testing
- `lua5.4 - <<'EOF'
package.path='./lua/?/main.lua;./lua/?.lua;./lua/?/init.lua;;'
local boot = require('aolite.ao.boot')(nil)
local msg={ Data="print('hi')", Tags={ ["On-Boot"]='Data' } }
boot(msg)
EOF`
- `lua5.4 - <<'EOF'
package.path='./lua/?/main.lua;./lua/?.lua;./lua/?/init.lua;;'
local aolite = require('aolite')
local tags={{name='On-Boot',value='Data'}}
aolite.spawnProcess('p1','print("hi boot")',tags)
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6842f590cc14832bbb56c0c8e891415c