### PR TITLE
Fix README code syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ aolite.spawnProcess(
   "process1",
   sourceCodeString,
   -- You must include the On-Boot tag to ensure the code is loaded.
-  {{ name: "On-Boot", value: "Data" }}
+  { { name = "On-Boot", value = "Data" } }
 )
 ```
 


### PR DESCRIPTION
## Summary
- fix Lua example table syntax in README

## Testing
- `lua -v`

------
https://chatgpt.com/codex/tasks/task_e_6842f7179d94832bbdac295556808694