### PR TITLE
Add examples directory with basic usage scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ Run the test script:
 lua test.lua
 ```
 
+## Examples
+
+Several small example scripts are available in the `examples` directory. Each of
+them can be run directly with `lua` and showcases different aspects of the
+library:
+
+- `ping_pong.lua` – minimal Ping/Pong handler.
+- `eval_example.lua` – evaluating code inside a running process.
+- `scheduler_example.lua` – using the manual scheduler and message queues.
+
+```bash
+lua examples/ping_pong.lua
+```
+
 ## API Overview
 
 `aolite` provides a simple API to interact with the emulated environment.

--- a/examples/eval_example.lua
+++ b/examples/eval_example.lua
@@ -1,0 +1,10 @@
+local ao = require("aolite")
+
+-- Spawn an empty process from the process template file
+-- Note the path uses dot notation and omits the .lua extension
+local procId = "evalproc"
+ao.spawnProcess(procId, "examples.process_template")
+
+-- Evaluate arbitrary code inside the process
+local result = ao.eval(procId, "return 2 + 3")
+print("Eval result:", result)

--- a/examples/ping_pong.lua
+++ b/examples/ping_pong.lua
@@ -1,0 +1,21 @@
+local ao = require("aolite")
+
+-- Spawn a simple process with a Ping handler
+local source = [[
+Handlers.add("Ping", function(msg)
+  msg.reply({ Action = "Pong" })
+end)
+]]
+
+local procId = "pinger"
+-- Note: On-Boot tag is mandatory when loading from string
+local tags = { { name = "On-Boot", value = "Data" } }
+ao.spawnProcess(procId, source, tags)
+
+-- Send a Ping message
+local msg = { From = procId, Target = procId, Action = "Ping" }
+ao.send(msg)
+
+-- Retrieve the response
+local resp = ao.getLastMsg(procId)
+print("Process replied with:", resp.Action)

--- a/examples/process_template.lua
+++ b/examples/process_template.lua
@@ -1,0 +1,3 @@
+-- This file is used by other examples to load a blank process.
+-- It simply prints a message when booted.
+print("Process loaded with ID: " .. ao.id)

--- a/examples/scheduler_example.lua
+++ b/examples/scheduler_example.lua
@@ -1,0 +1,25 @@
+local ao = require("aolite")
+
+-- Create two processes that just log messages
+local source = [[
+Handlers.add("Print", function(msg)
+  print(ao.id .. " received: " .. (msg.Data or ""))
+end)
+]]
+
+local p1, p2 = "proc1", "proc2"
+ao.spawnProcess(p1, source, { { name = "On-Boot", value = "Data" } })
+ao.spawnProcess(p2, source, { { name = "On-Boot", value = "Data" } })
+
+-- Disable auto scheduling to control when messages are processed
+ao.setAutoSchedule(false)
+
+-- Queue some messages
+ao.queue({ From = p1, Target = p2, Action = "Print", Data = "Hello" })
+ao.queue({ From = p2, Target = p1, Action = "Print", Data = "World" })
+
+print("No messages processed yet")
+
+-- Run the scheduler manually
+ao.runScheduler()
+


### PR DESCRIPTION
## Summary
- create `examples` directory with working scripts
- showcase usage of aolite for ping/pong, eval, and scheduling
- document the examples in the README

## Testing
- `lua examples/ping_pong.lua`
- `lua examples/eval_example.lua`
- `lua examples/scheduler_example.lua`


------
https://chatgpt.com/codex/tasks/task_e_6842fab2a114832bb8d36f9a3aca8d5b