### PR TITLE
Add getMsg API function

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ lua examples/ping_pong.lua
 - `aolite.getAllMsgs(processId)`: Returns all messages sent to a given process.
 - `aolite.getLastMsg(processId)`: Returns only the last message sent to a given process.
 - `aolite.getFirstMsg(processId)`: Returns only the first message sent to a given process.
+- `aolite.getMsg(messageId)`: Retrieve a specific message by its unique ID.
 - `aolite.eval(processId, expression)`: Evaluates a Lua expression within the context of a given process and returns the result.
 - `aolite.setAutoSchedule(boolean)`: Enable or disable automatic scheduling after each `send`.
 - `aolite.runScheduler()`: Manually trigger the scheduler to process message queues.

--- a/lua/aolite/api.lua
+++ b/lua/aolite/api.lua
@@ -55,6 +55,10 @@ function api.getAllMsgs(env, processId, matchSpec)
   return proc.process.getMsgs(matchSpec, false)
 end
 
+function api.getMsg(env, messageId)
+  return env.messageStore[messageId]
+end
+
 function api.eval(env, processId, expression)
   assert(type(processId) == "string", "processId must be defined")
   api.send(env, {

--- a/lua/aolite/main.lua
+++ b/lua/aolite/main.lua
@@ -35,7 +35,7 @@ function M.getAllMsgs(processId, matchSpec)
 end
 
 function M.getMsg(messageId)
-  return env.messageStore[messageId]
+  return api.getMsg(env, messageId)
 end
 
 function M.eval(processId, expression)

--- a/spec/get_msg_spec.lua
+++ b/spec/get_msg_spec.lua
@@ -1,0 +1,36 @@
+local aolite = require("aolite")
+
+local PING_SRC = [[
+Handlers.add("Ping", function(msg)
+  msg.reply({ Action = "Pong", Data = msg.Data })
+end)
+]]
+
+describe("aolite.getMsg", function()
+  before_each(function()
+    aolite.clearAllProcesses()
+    aolite.spawnProcess("sender", "return true", {
+      { name = "On-Boot", value = "Data" },
+    })
+    aolite.spawnProcess("receiver", PING_SRC, {
+      { name = "On-Boot", value = "Data" },
+    })
+  end)
+
+  it("fetches a message by ID", function()
+    aolite.send({
+      From = "sender",
+      Target = "receiver",
+      Action = "Ping",
+      Data = "hello",
+      Tags = { { name = "Reference", value = "1" } },
+    })
+
+    local resp = aolite.getLastMsg("sender")
+    assert.is_not_nil(resp)
+
+    local fetched = aolite.getMsg(resp.Id)
+    assert.is_not_nil(fetched)
+    assert.are.same(resp, fetched)
+  end)
+end)


### PR DESCRIPTION
## Summary
- add `getMsg` to API implementation
- expose it through main module
- document `getMsg` in the README
- test fetching a message by ID

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68432a5dcaac832b9f08a832f0f5f851