### PR TITLE
Enhance scheduler example and tests

### DIFF
--- a/examples/scheduler_example.lua
+++ b/examples/scheduler_example.lua
@@ -1,24 +1,49 @@
 local ao = require("aolite")
 
--- Create two processes that just log messages
+-- Processes simply print any messages they receive
 local source = [[
 Handlers.add("Print", function(msg)
   print(ao.id .. " received: " .. (msg.Data or ""))
+  -- echo back to sender so we can observe ordering
+  msg.reply({ Action = "Ack", Data = msg.Data })
 end)
 ]]
 
 local p1, p2 = "proc1", "proc2"
-ao.spawnProcess(p1, source, { { name = "On-Boot", value = "Data" } })
-ao.spawnProcess(p2, source, { { name = "On-Boot", value = "Data" } })
+local boot = { { name = "On-Boot", value = "Data" } }
+ao.spawnProcess(p1, source, boot)
+ao.spawnProcess(p2, source, boot)
 
--- Disable auto scheduling to control when messages are processed
+-- We'll control the scheduler manually
 ao.setAutoSchedule(false)
 
--- Queue some messages
-ao.send({ From = p1, Target = p2, Action = "Print", Data = "Hello" })
-ao.send({ From = p2, Target = p1, Action = "Print", Data = "World" })
+-- Queue several messages in both directions
+ao.send({ From = p1, Target = p2, Action = "Print", Data = "one" })
+ao.send({ From = p1, Target = p2, Action = "Print", Data = "two" })
+ao.send({ From = p2, Target = p1, Action = "Print", Data = "alpha" })
+ao.send({ From = p2, Target = p1, Action = "Print", Data = "beta" })
 
-print("No messages processed yet")
+print("== Original queues ==")
+local q1 = ao.listQueueMessages(p1)
+for i, msg in ipairs(q1) do
+  print("p1[" .. i .. "]: " .. msg.Data)
+end
+local q2 = ao.listQueueMessages(p2)
+for i, msg in ipairs(q2) do
+  print("p2[" .. i .. "]: " .. msg.Data)
+end
 
--- Run the scheduler manually
+-- Reverse the order for each queue
+ao.reorderQueue(p1, { q1[2].Id, q1[1].Id })
+ao.reorderQueue(p2, { q2[2].Id, q2[1].Id })
+
+print("== Reordered queues ==")
+for i, msg in ipairs(ao.listQueueMessages(p1)) do
+  print("p1[" .. i .. "]: " .. msg.Data)
+end
+for i, msg in ipairs(ao.listQueueMessages(p2)) do
+  print("p2[" .. i .. "]: " .. msg.Data)
+end
+
+-- Process all messages
 ao.runScheduler()

--- a/spec/scheduler_spec.lua
+++ b/spec/scheduler_spec.lua
@@ -1,0 +1,46 @@
+local aolite = require("aolite")
+
+local PING_SRC = [[
+Handlers.add("Ping", function(msg)
+  msg.reply({ Action = "Pong", Data = msg.Data })
+end)
+]]
+
+describe("scheduler queue reordering", function()
+  before_each(function()
+    aolite.clearAllProcesses()
+    aolite.spawnProcess("p1", PING_SRC, { { name = "On-Boot", value = "Data" } })
+    aolite.spawnProcess("p2", PING_SRC, { { name = "On-Boot", value = "Data" } })
+    aolite.setAutoSchedule(false)
+  end)
+
+  it("reorders messages for multiple processes", function()
+    -- queue messages to both processes
+    aolite.send({ From = "p1", Target = "p2", Action = "Ping", Data = "A" })
+    aolite.send({ From = "p1", Target = "p2", Action = "Ping", Data = "B" })
+    aolite.send({ From = "p2", Target = "p1", Action = "Ping", Data = "1" })
+    aolite.send({ From = "p2", Target = "p1", Action = "Ping", Data = "2" })
+
+    local q1 = aolite.listQueueMessages("p1")
+    local q2 = aolite.listQueueMessages("p2")
+    assert.are.equal(2, #q1)
+    assert.are.equal(2, #q2)
+
+    -- reverse both queues
+    aolite.reorderQueue("p1", { q1[2].Id, q1[1].Id })
+    aolite.reorderQueue("p2", { q2[2].Id, q2[1].Id })
+
+    aolite.runScheduler()
+
+    -- check that replies arrived in the new order
+    local firstP1 = aolite.getFirstMsg("p1", { From = "p2", Action = "Pong" })
+    local lastP1 = aolite.getLastMsg("p1", { From = "p2", Action = "Pong" })
+    assert.are.equal("B", firstP1.Data)
+    assert.are.equal("A", lastP1.Data)
+
+    local firstP2 = aolite.getFirstMsg("p2", { From = "p1", Action = "Pong" })
+    local lastP2 = aolite.getLastMsg("p2", { From = "p1", Action = "Pong" })
+    assert.are.equal("2", firstP2.Data)
+    assert.are.equal("1", lastP2.Data)
+  end)
+end)


### PR DESCRIPTION
## Summary
- show how to reorder message queues in `scheduler_example.lua`
- add a dedicated scheduler spec covering queue reordering across processes

## Testing
- `make LUA=lua5.4 test`

------
https://chatgpt.com/codex/tasks/task_e_684942aa9458832bb882838923a851ec