### PR TITLE
Improve AGENTS docs and add repo guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+### Title
+
+**AOLite Repository Guide (root)**
+
+---
+
+### Overview
+
+This repository contains the AOLite local AO simulation toolkit. The Lua modules live under `lua/aolite`, example scripts under `examples`, and Busted tests under `spec`. AGENTS files exist at `lua/aolite/`, `lua/aolite/lib/`, and `lua/aolite/ao/` describing those parts in detail.
+
+### File Summaries
+
+| Path            | Purpose                                                  |
+| --------------- | -------------------------------------------------------- |
+| `lua/aolite`    | Main entry modules, scheduler and API wrappers.         |
+| `lua/aolite/lib`| Utility libraries used everywhere.                      |
+| `lua/aolite/ao` | Embedded AO runtime executed inside each process.       |
+| `examples`      | Standalone scripts demonstrating AOLite usage.          |
+| `spec`          | Unit tests using Busted.                                |
+
+### Testing
+
+Run the test suite from the repository root:
+
+```bash
+luarocks install busted  # once
+make test
+```
+
+### Relationships
+
+The high level modules in `lua/aolite` depend on helpers in `lua/aolite/lib` and on the runtime in `lua/aolite/ao`. Example scripts and tests import the top level module defined in `lua/aolite/main.lua`.
+
+### Contribution & Style
+
+* Use **2 spaces** for indentation in Lua files and avoid tabs.
+* End files with a newline and trim trailing whitespace.
+* Reference lines for citations using `F:path#Lstart(-Lend)` where applicable.
+* Always run `make test` before committing.
+* PR messages should summarize changes and include test results.
+
+This root document provides a quick map of the repository. See nested AGENTS files for deeper technical details and the standard heading layout used across them.

--- a/lua/aolite/AGENTS.md
+++ b/lua/aolite/AGENTS.md
@@ -8,6 +8,8 @@
 
 AOLite embeds the **AO runtime** inside a single Lua VM so tests or back-tests can create many processes, queue messages, reorder queues, and drive a deterministic coroutine-based scheduler — **all without Arweave / Bundlr or a real network**.
 
+Refer to the root `AGENTS.md` for repository structure.  The lower level utility modules are documented in `lua/aolite/lib/AGENTS.md` while the embedded runtime is described in `lua/aolite/ao/AGENTS.md`.
+
 ---
 
 ### Key Data Structures & Fields
@@ -92,3 +94,13 @@ AOLite embeds the **AO runtime** inside a single Lua VM so tests or back-tests c
 * **In-process `require(module, processEnv)`** (second arg) triggers sandboxed chunk load to keep globals isolated.
 
 The documentation above enables another LLM to reconstruct the full in-memory simulation pipeline, implement additional utilities, or generate tests that leverage AOLite’s local AO environment.
+
+### Testing
+
+Run the repository level tests with:
+
+```bash
+make test
+```
+
+Refer to the root `AGENTS.md` for additional contribution guidelines.

--- a/lua/aolite/ao/AGENTS.md
+++ b/lua/aolite/ao/AGENTS.md
@@ -12,6 +12,8 @@ Core surfaces two primary objects to every script:
 * **`ao`** – sandboxed gateway for messaging, spawning, assignment & misc helpers.
 * **`Handlers`** – dynamic registry that routes inbound messages (or cron ticks) to user callbacks.
 
+See `../AGENTS.md` for how this runtime integrates with the surrounding modules and consult the root `AGENTS.md` for contribution guidelines.
+
 ---
 
 ### Key Data Structures & Fields
@@ -108,3 +110,11 @@ print("received", resp.Action)
 ```
 
 An LLM can now reconstruct full agent behavior, extend the runtime, or generate new processes using only the abstractions documented above.
+
+### Testing
+
+Run all tests from the repository root:
+
+```bash
+make test
+```

--- a/lua/aolite/lib/AGENTS.md
+++ b/lua/aolite/lib/AGENTS.md
@@ -16,6 +16,8 @@ Foundational helper layer for AOLite agents:
 
 All other runtime packages (e.g. `ao`, `process`) lean on this folder for math, encoding, logging, pattern matching and pure-Lua functional glue.
 
+Refer to the root `AGENTS.md` for repository layout and contribution guidelines. The main runtime using these helpers is documented in `../ao/AGENTS.md`.
+
 ---
 
 ### Key Data Structures & Fields
@@ -112,3 +114,11 @@ All other runtime packages (e.g. `ao`, `process`) lean on this folder for math, 
 ---
 
 With these modules documented, an LLM can fully emulate math, encoding, logging, serialization and functional helpers that the larger AOLite agent runtime expects.
+
+### Testing
+
+Run the repository test suite:
+
+```bash
+make test
+```


### PR DESCRIPTION
## Summary
- add a root AGENTS guide describing repository layout and style
- cross-link AGENTS files and add test instructions
- unify testing header wording

## Testing
- `make test` *(fails: luarocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a921ba670832b9d4119e4903765bd