### PR TITLE
Custom Process Modules

### DIFF
--- a/lua/aolite/factories/ao.lua
+++ b/lua/aolite/factories/ao.lua
@@ -1,7 +1,9 @@
 local compat_require = require -- dualRequire from aolite.compat
 
 -- Build a fresh upstream AO instance executed inside a per-process sandbox
-return function(Handlers)
+return function(processId, moduleId, Handlers)
+  assert(type(processId) == "string", "processId must be a string")
+  assert(type(moduleId) == "string", "moduleId must be a string")
   assert(type(Handlers) == "table", "Handlers table expected")
 
   ---------------------------------------------------------------------------
@@ -65,6 +67,10 @@ return function(Handlers)
   ---------------------------------------------------------------------------
   local assignment = env.require(".assignment")
   assignment.init(ao)
+
+  ao.authorities = { "DummyAuthority" } -- TODO: improve
+  ao.id = processId
+  ao._module = moduleId
 
   return ao
 end

--- a/lua/aolite/process.lua
+++ b/lua/aolite/process.lua
@@ -203,6 +203,7 @@ function process.spawnProcess(env, processId, dataOrPath, initEnv, ownerId)
     error("aolite: Process with ID " .. processId .. " already exists")
   end
   local moduleId = tagMap.Module or "DefaultDummyModule"
+  log.debug("> LOG: Spawning process id:" .. processId .. " & module:" .. moduleId)
 
   local processModule = createProcess(processId, moduleId)
 

--- a/lua/aolite/process.lua
+++ b/lua/aolite/process.lua
@@ -283,6 +283,13 @@ function process.spawnProcess(env, processId, dataOrPath, initEnv, ownerId)
         if not ao.isAssignment(msg) and env.processed[msg.Id] then
           error("aolite: Message already processed: " .. msg.Id)
         end
+        if runtimeEnv.Process.Tags[1] == nil then -- not an array any more
+          local arr = {}
+          for k, v in pairs(runtimeEnv.Process.Tags) do
+            table.insert(arr, { name = k, value = v })
+          end
+          runtimeEnv.Process.Tags = arr
+        end
         processModule.handle(msg, runtimeEnv)
         env.processed[msg.Id] = true
       end

--- a/spec/module_spec.lua
+++ b/spec/module_spec.lua
@@ -1,4 +1,6 @@
 local aolite = require("aolite")
+local utils = require(".utils")
+local log = require(".log")
 
 describe("module & From-Module tag", function()
   before_each(function()
@@ -28,5 +30,114 @@ describe("module & From-Module tag", function()
     local res = aolite.getLastMsg("user-process-1")
     assert.is_not_nil(res)
     assert.are.equal("module-2", res.Tags["From-Module"])
+  end)
+
+  it("From-Module and Module properly set on spawned process", function()
+    local spawnId = aolite.eval(
+      "user-process-1",
+      [[
+        local resp = ao.spawn("other-module", {
+          Tags = {
+            ['Authority'] = ao.authorities[1],
+          },
+        }).receive()
+
+        return resp.Process
+      ]]
+    )
+
+    local processEnv = aolite.eval(spawnId, "return ao.env.Process")
+    log.debug("processEnv", processEnv)
+    assert.is_not_nil(processEnv)
+    assert.are.equal("module-1", processEnv.Tags["From-Module"])
+    assert.are.equal("other-module", processEnv.Tags["Module"])
+  end)
+
+  it("keeps Module and From-Module after two messages", function()
+    -- parent spawns a child written in a different module
+    local childId = aolite.eval(
+      "user-process-1",
+      [[
+        local resp = ao.spawn("other-module", {
+          Tags = { ['Authority'] = ao.authorities[1] },
+        }).receive()
+        return resp.Process
+      ]]
+    )
+
+    -- first and second message to the child (bug used to surface after the 2nd)
+    aolite.send({ From = "user-process-1", Target = childId, Data = "ping-1" })
+    aolite.send({ From = "user-process-1", Target = childId, Data = "ping-2" })
+
+    -- inspect the process environment of the child
+    local tags = aolite.eval(childId, "return ao.env.Process.Tags")
+    assert.is_not_nil(tags, "Tags table should exist")
+    assert.are.equal("other-module", tags["Module"])
+    assert.are.equal("module-1", tags["From-Module"])
+  end)
+end)
+
+describe("custom Lua module loader", function()
+  before_each(function()
+    aolite.clearAllProcesses()
+    aolite.spawnProcess("user-proc", nil)
+    aolite.spawnProcess("echo-proc", nil, { ["Module"] = "spec.modules.module_echo" })
+  end)
+
+  it("loads the custom module and processes a message", function()
+    local payload = "Hello from test"
+
+    aolite.send({
+      From = "user-proc",
+      Target = "echo-proc",
+      Data = payload,
+      Action = "Ping",
+    })
+
+    -- The echo module should reply back to the sender ("user-proc").
+    local res = aolite.getLastMsg("user-proc")
+    assert.is_not_nil(res)
+    assert.are.equal(payload, res.Data)
+    assert.are.equal(
+      "spec.modules.module_echo",
+      res.Tags["From-Module"],
+      "From-Module tag should reflect the custom module id"
+    )
+  end)
+end)
+
+describe("module returning Spawns table", function()
+  before_each(function()
+    aolite.clearAllProcesses()
+    aolite.spawnProcess("spawner-proc", nil, { ["Module"] = "spec.modules.module_spawn" })
+  end)
+
+  it("converts outbox.Spawns into a Spawned message", function()
+    aolite.send({ From = "spawner-proc", Target = "spawner-proc", Action = "Spawn" })
+
+    local msg = aolite.getLastMsg("spawner-proc", { Action = "Spawned" })
+    assert.is_not_nil(msg)
+    assert.are.equal("spawner-proc", msg.From)
+    assert.are.equal("Spawned", msg.Action)
+    -- Since we are not using the default AO module,
+    -- tags are not parsed and put into a map.
+    local fromModule = utils.find(function(t)
+      return t.name == "From-Module"
+    end, msg.Tags).value
+    assert.are.equal("spec.modules.module_spawn", fromModule)
+  end)
+
+  it("converts outbox.Spawns into a Spawned message", function()
+    aolite.send({ From = "spawner-proc", Target = "spawner-proc", Action = "Spawn" })
+
+    local msg = aolite.getLastMsg("spawner-proc", { Action = "Spawned" })
+    local processId = msg.Process
+
+    aolite.spawnProcess("user", nil)
+    aolite.send({ From = "user", Target = processId, Action = "Spawn" })
+
+    local res = aolite.getLastMsg(processId)
+    assert.is_not_nil(res)
+    assert.are.equal("Spawned", res.Action)
   end)
 end)

--- a/spec/modules/module_echo.lua
+++ b/spec/modules/module_echo.lua
@@ -1,0 +1,34 @@
+local reference = 0
+local process = { _version = "0.0.1" }
+
+function process.handle(msg, _)
+  -- Build a minimal outbox echoing the received data back to the sender
+  local outbox = {
+    Assignments = {},
+    Messages = {},
+    Spawns = {},
+    Output = "echoed message " .. msg.Id .. " back to " .. msg.From,
+  }
+
+  local reply = {
+    Target = msg.From,
+    Data = msg.Data,
+    Anchor = string.format("%032d", reference),
+    Tags = {
+      { name = "Reference", value = tostring(reference) },
+    },
+  }
+
+  -- Bubble the Action tag through if it exists so the test can match on it
+  for _, tag in ipairs(msg.Tags or {}) do
+    if tag.name == "Action" then
+      table.insert(reply.Tags, { name = "Action", value = tag.value })
+    end
+  end
+
+  table.insert(outbox.Messages, reply)
+  reference = reference + 1
+  return outbox
+end
+
+return process

--- a/spec/modules/module_spawn.lua
+++ b/spec/modules/module_spawn.lua
@@ -1,0 +1,10 @@
+return {
+  handle = function(msg, env)
+    for _, tag in ipairs(msg.Tags) do
+      if tag.name == "Action" and tag.value == "Spawn" then
+        env.ao.spawn("spec.modules.module_spawn", {})
+      end
+    end
+    return env.ao.outbox
+  end,
+}


### PR DESCRIPTION
This pull request introduces the ability to use custom Lua modules when spawning processes.

### Custom Modules
* `lua/aolite/factories/process.lua`: Refactored process creation to dynamically load custom Lua modules using `moduleId`. Added fallback to reference AOS module implementation if custom modules fail to load. Persisted process references for simulator access.

### Message Handling Improvements:
* `lua/aolite/process.lua`: Enhanced message tagging by ensuring `From-Module` and `Module` tags are properly set and retained across multiple messages. This also ensures ao.env.Process.Tags are retained.
### Testing Enhancements:
* `spec/module_spec.lua`: Expanded test suite to verify correct handling of `Module` and `From-Module` tags, proper loading of custom modules, and correct behavior of spawned processes. Also added tests for custom modules.

### Custom Module Examples:
Some simple custom modules were added to the specs to test and demonstrate their usage.
* `spec/modules/module_echo.lua`: Introduced a custom module (`module_echo`) that simply echoes received messages back to the sender.
* `spec/modules/module_spawn.lua`: Added a custom module (`module_spawn`) that spawns new processes based on specific message actions, showcasing dynamic process creation and making use of the injected env directly from the `handle` method.

These changes collectively enhance the modularity, extensibility, and robustness of the `aolite` framework, enabling better support for custom Lua modules and sandboxed environments.