### PR TITLE
Process Output Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A local, concurrent emulation of the Arweave AO protocol for testing Lua process
 - **Message Passing:** A simple API for sending messages between processes.
 - **Process State Access:** Directly run Eval inside any process to access or modify its state.
 - **Scheduler Control:** Supports both automatic and manual scheduling of process message queues.
-- **Controlled Logging:** Supports logging at different levels of verbosity.
+- **Controlled Logging:** Supports logging at different levels of verbosity, logging to a file, and logging process output.
 
 ## Requirements
 
@@ -125,6 +125,8 @@ lua examples/ping_pong.lua
 - `aolite.listQueueMessages(processId)`: Get the full list of messages in the queue for a specific process.
 - `aolite.reorderQueue(processId, msgIds)`: Manually reorder the queue for a specific process.
 - `aolite.clearAllProcesses()`: Clears all processes from the environment.
+- `aolite.setMessageLog(path)`: Set the path to a file where all messages will be logged.
+- `aolite.setPrintProcessOutput(boolean)`: Enable or disable printing process output with `log.debug`
 
 ## Logging
 
@@ -149,6 +151,25 @@ and use the log module yourself:
 local log = require("aolite.lib.log")
 log.debug("This is a debug message")
 ```
+
+### Process Output
+
+If you wish to capture process output and print it to stdout (using `log.debug`, so PrintVerb needs to be set to 3), set the
+`AOLITE_PRINT_OUTPUT` environment variable to a non-empty, non-"0" value.
+
+```bash
+AOLITE_PRINT_OUTPUT=1 lua test.lua
+```
+
+You can also toggle this at runtime using `aolite.setPrintProcessOutput`:
+
+```lua
+aolite.setPrintProcessOutput(true)
+```
+
+This allows you to see the output (from the process's outbox.Output) of processes as they run, which is useful for debugging. The default AOS module puts all `print` statements into the outbox.Output.
+
+### File Logging
 
 If you wish to capture every message exchanged between processes, set the
 `AOLITE_MSG_LOG` environment variable to a file path or configure it at runtime

--- a/lua/aolite/env.lua
+++ b/lua/aolite/env.lua
@@ -10,6 +10,7 @@ function LocalAOEnv.new()
     ready = {}, -- set of processIds that have messages (and need scheduling)
     autoSchedule = true,
     messageLogPath = os.getenv("AOLITE_MSG_LOG"),
+    printProcessOutput = (os.getenv("AOLITE_PRINT_OUTPUT") or "") ~= "" and os.getenv("AOLITE_PRINT_OUTPUT") ~= "0",
   }
   return self
 end

--- a/lua/aolite/eval.lua
+++ b/lua/aolite/eval.lua
@@ -28,3 +28,7 @@ Handlers.add("EvalRequestHandler", "EvalRequest", function(msg)
     })
   end
 end)
+
+-- NOTE: This is simply to silence the EvalResponse message generated above
+--       (prevents the default handler from printing a new message received)
+Handlers.prepend("EvalResponseHandler", "EvalResponse", function() end)

--- a/lua/aolite/main.lua
+++ b/lua/aolite/main.lua
@@ -124,4 +124,15 @@ function M.reorderQueue(processId, newOrderIds)
   end
 end
 
+function M.setPrintProcessOutput(mode)
+  if type(mode) ~= "boolean" then
+    error("setPrintProcessOutput expects a boolean")
+  end
+  env.printProcessOutput = mode
+end
+
+function M.isPrintProcessOutput()
+  return env.printProcessOutput == true
+end
+
 return M

--- a/spec/module_spec.lua
+++ b/spec/module_spec.lua
@@ -47,7 +47,6 @@ describe("module & From-Module tag", function()
     )
 
     local processEnv = aolite.eval(spawnId, "return ao.env.Process")
-    log.debug("processEnv", processEnv)
     assert.is_not_nil(processEnv)
     assert.are.equal("module-1", processEnv.Tags["From-Module"])
     assert.are.equal("other-module", processEnv.Tags["Module"])


### PR DESCRIPTION
This pull request introduces the ability to display a process' `outbox.Output` value. This is typically where the default AOS module stores values passed to the global `print`.

### Logging Improvements
* **Process Output Logging (`README.md`, `lua/aolite/process.lua`)**: Added functionality to capture and print process output (e.g., `outbox.Output`) to stdout, both on boot and during runtime, when enabled. This can be toggled with `aolite.setPrintProcessOutput` or by using the `AOLITE_PRINT_OUTPUT` environment variable.
* **Log Formatting Updates (`lua/aolite/process.lua`)**: Improved log message formatting with clearer prefixes for better readability during debugging.

### Code Cleanup:
* **Removed Redundant Debug Logs (`spec/module_spec.lua`)**: Eliminated unnecessary debug logging in test specifications for cleaner output.