### PR TITLE
Stop using process' Inbox to store messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ lua examples/ping_pong.lua
 -`aolite` provides a simple API to interact with the emulated environment.
 
 - `aolite.spawnProcess(processId, dataOrPath, tags)`: Spawns a new process from source code or a file path.
-- `aolite.send(msg)`: Sends a message to a process. The scheduler runs automatically by default.
+- `aolite.send(msg)`: Sends a message to a process The scheduler runs automatically by 
+default.
+- `aolite.clearAllMessages(processId)`: Clears *only* the message history (internal to aolite) of the given process without touching other state.
 - `aolite.getAllMsgs(processId)`: Returns all messages sent to a given process.
 - `aolite.getLastMsg(processId)`: Returns only the last message sent to a given process.
 - `aolite.getFirstMsg(processId)`: Returns only the first message sent to a given process.

--- a/lua/aolite/main.lua
+++ b/lua/aolite/main.lua
@@ -12,14 +12,19 @@ function M.spawnProcess(originalId, dataOrPath, tags)
   return process.spawnProcess(env, originalId, dataOrPath, tags)
 end
 
-function M.send(msg, clearInbox)
-  local queuedMsg = api.send(env, msg, clearInbox)
+function M.send(msg)
+  local queuedMsg = api.send(env, msg)
 
   if env.autoSchedule then
     scheduler.run(env)
   end
 
   return queuedMsg
+end
+
+-- Clear per-process message history (Inbox + aolite history bucket)
+function M.clearAllMessages(processId)
+  return api.clearAllMessages(env, processId)
 end
 
 function M.getFirstMsg(processId, matchSpec)
@@ -62,6 +67,7 @@ function M.clearAllProcesses()
   env.processed = {}
   env.ready = {}
   env.coroutines = {}
+  env.history = {}
   -- defensive: clear any stray global fallback inbox
   _G.Inbox = {}
 end

--- a/lua/aolite/process.lua
+++ b/lua/aolite/process.lua
@@ -118,6 +118,22 @@ local function addMsgToQueue(env, msg)
     env.messageStore[msg.Id] = msg
     table.insert(env.queues[msg.Target], msg.Id)
 
+    env.history = env.history or {}
+    env.history[msg.Target] = env.history[msg.Target] or {}
+    local hist = env.history[msg.Target]
+    if
+      msg.Id
+      and not (function()
+        for _, id in ipairs(hist) do
+          if id == msg.Id then
+            return true
+          end
+        end
+      end)()
+    then
+      table.insert(hist, msg.Id)
+    end
+
     local action = findTag(msg.Tags, "Action")
     if action ~= "EvalRequest" and action ~= "EvalResponse" then
       log.debug(
@@ -191,6 +207,14 @@ function process.deliverOutbox(env, fromId, pushedFor)
           if env.queues[pid] then
             table.insert(env.queues[pid], refMsg.Id)
             env.ready[pid] = true
+
+            -- Keep per-process history consistent: record the assignment for
+            -- each recipient so helper functions (getMsgs, etc.) return
+            -- accurate data even for messages delivered via Assignments.
+            env.history = env.history or {}
+            env.history[pid] = env.history[pid] or {}
+            local hist = env.history[pid]
+            table.insert(hist, refMsg.Id)
           else
             error("aolite: Target process not found: " .. tostring(pid))
           end

--- a/spec/assignment_spec.lua
+++ b/spec/assignment_spec.lua
@@ -53,6 +53,12 @@ describe("ao.assign", function()
       Data = "Hello, world!",
     })
 
+    local lastMsg1 = aolite.getLastMsg("receiver-1")
+    local lastMsg2 = aolite.getLastMsg("receiver-2")
+    assert.are.equal("Assign-Test", lastMsg1.Action)
+    assert.are.equal("Assign-Test", lastMsg2.Action)
+    assert.are.equal(lastMsg1.Id, lastMsg2.Id)
+
     local state1 = aolite.eval("receiver-1", "MY_STATE")
     local state2 = aolite.eval("receiver-2", "MY_STATE")
     assert.are.equal("Hello, world!", state1)


### PR DESCRIPTION
## Deterministic message history, no more Inbox tampering

This pull-request removes the last simulator writes to a module’s internal
`Inbox` table and introduces a clean, authoritative *history* mechanism for
all message-introspection helpers (`getMsgs`, `getLastMsg`, …).

### Why  
Writing into the sandbox Inbox let user code accidentally (or intentionally) mutate simulator state.  This could cause accidental duplication or loss of certain messages.

### What changed  

| Area | Old behaviour | New behaviour |
|------|---------------|---------------|
| **Message book-keeping** | Simulator inserted the full message table into the sandbox Inbox **plus** stored a reference globally. | Simulator stores the Id once in `env.history[pid]` (arrival order) and keeps the full object in `env.messageStore`. No writes to the module Inbox. |
| **Assignments** | Only the first recipient had the message in its helper history. | `deliverOutbox` now puts the message Id into every recipient’s `history[pid]`. |
| **getMsgs fallback** | Scanned the sandbox Inbox and could return duplicates / wrong process. | Reads exclusively from `env._parent.history[processId]`; messages are unique and immune to sandbox mutations. |
| **API – `aolite.send`** | Optional `clearInbox` flag. | Flag removed. Cleaning history is now an explicit call. |
| **New helper** | — | `aolite.clearAllMessages(processId)` (via `api.clearAllMessages`) clears the simulator history for one process. |
| **Process reset** | — | `aolite.clearAllProcesses()` resets `env.history` as well. |
| **Docs** | Mentioned `clearInbox`. | Updated README & `factories/AGENTS.md` to describe the new history model and the new helper. |

### Code highlights  
* **lua/aolite/process.lua**  
  * added per-process `env.history` tracking in `addMsgToQueue`  
  * updated `deliverOutbox` to synchronise assignments  
* **lua/aolite/factories/process.lua**  
  * removed all writes into `env.Inbox`  
  * `getMsgs` now resolves via history  
* **lua/aolite/api.lua & main.lua**  
  * dropped `clearInbox` parameter  
  * introduced `clearAllMessages` helper  
* **Tests**  
  * Added/updated specs to assert correct behaviour for broadcast assignments & transfer notices.  
* **Docs**  
  * README + `factories/AGENTS.md` fully rewritten where necessary.

### Migration guide  
1. **Stop passing the second argument to `aolite.send`.**  
   ```lua
   -- before
   aolite.send(msg, true)
   -- now
   aolite.send(msg)
   ```
2. If you relied on `clearInbox(true)` semantics, call  
   ```lua
   aolite.clearAllMessages("my-process-id")
   ```  
   instead, where "my-process-id" is the ID you passed in the `From` field of your previous `aolite.send(msg, true)`
3. Any direct reads from `Inbox` inside tests should be switched to
   `aolite.get*Msg*` helpers.

No changes are required inside AO modules themselves. The AOS module still has a working Inbox table, and aolite no longer touches it.

### Backwards compatibility  
* Public API is 100 % backward-compatible **except** for the removed
  `clearInbox` flag on `aolite.send` which is now ignored and can be removed.  